### PR TITLE
提出先urlの調査

### DIFF
--- a/experiment/submit_url.py
+++ b/experiment/submit_url.py
@@ -1,23 +1,27 @@
 import requests
 import bs4
+from http.cookies import SimpleCookie
 
 #%%
-cookie = {
-}
+cookie_raw = ""
+simple_cookie = SimpleCookie()
+simple_cookie.load(cookie_raw)
+cookie = {k : v.value for k, v in simple_cookie.items()}
 
 csrf_token = None
-def get_csrf_token(force=False):
+base_url = "https://beta.atcoder.jp/contests/"
+def get_csrf_token(prob, force=False):
     global csrf_token
     if force or csrf_token is None:
-        response = requests.get(headers["referer"], cookies=cookie)
+        response = requests.get(base_url + prob, cookies=cookie)
         soup = bs4.BeautifulSoup(response.text, "lxml")
 
         csrf_token = soup.select_one("input[name=csrf_token]")["value"]
     return csrf_token
 
 def submit(prob, prob_number, prob_hard, lang, source_code):
-    csrf_token = get_csrf_token()
-    url = "https://beta.atcoder.jp/contests/{}{}/submit".format(prob, prob_number)
+    csrf_token = get_csrf_token(prob)
+    url = base_url + "{}{}/submit".format(prob, prob_number)
     data = {
         "data.TaskScreenName": "{}{}_{}".format(prob, prob_number, prob_hard),
         "data.LanguageId": lang,

--- a/experiment/submit_url.py
+++ b/experiment/submit_url.py
@@ -34,7 +34,6 @@ prob_hard = "a"
 lang = "3023"
 
 source_code = """
-print("ABC" if int(input()) < 1000 else "ABD")
 """
 
 submit(prob, prob_number, prob_hard, lang, source_code)

--- a/experiment/submit_url.py
+++ b/experiment/submit_url.py
@@ -1,0 +1,40 @@
+import requests
+import bs4
+
+#%%
+cookie = {
+}
+
+csrf_token = None
+def get_csrf_token(force=False):
+    global csrf_token
+    if force or csrf_token is None:
+        response = requests.get(headers["referer"], cookies=cookie)
+        soup = bs4.BeautifulSoup(response.text, "lxml")
+
+        csrf_token = soup.select_one("input[name=csrf_token]")["value"]
+    return csrf_token
+
+def submit(prob, prob_number, prob_hard, lang, source_code):
+    csrf_token = get_csrf_token()
+    url = "https://beta.atcoder.jp/contests/{}{}/submit".format(prob, prob_number)
+    data = {
+        "data.TaskScreenName": "{}{}_{}".format(prob, prob_number, prob_hard),
+        "data.LanguageId": lang,
+        "sourceCode": source_code,
+        "csrf_token": csrf_token,
+    }
+
+    return requests.post(url, data=data, cookies=cookie)
+
+#%%
+prob = "abc"
+prob_number = "099"
+prob_hard = "a"
+lang = "3023"
+
+source_code = """
+print("ABC" if int(input()) < 1000 else "ABD")
+"""
+
+submit(prob, prob_number, prob_hard, lang, source_code)


### PR DESCRIPTION
# 概要
issue: #7
* 問題の名前(abc001_aなど)
* 言語id(pythonだと3023)
* ログイン情報があれば提出できそうです。

以下のurlに必要な情報揃えてpostをぶん投げます。
https://beta.atcoder.jp/contests/{{ここに問題名(abc001)}}/submit
 
 ## 変更内容
試験用ディレクトリとして、experiment作りました。
実験ファイルとか、ここに集めていきませんか。

---

cookieの手動での取得方法ですが、下の図にある文字列をコード中のcookie_rawに突っ込んでください。

<img width="1024" alt="2018-08-16 15 12 24" src="https://user-images.githubusercontent.com/12852948/44191925-559fb200-a168-11e8-8638-16beb83cf567.png">

間違えてpythonで書いてしまったのですが、直接atamに関わってくるものではないと思ったのでこのままPR出します。

 ## 影響範囲
特になし

 ## 動作要件
* python
* requests

 ## 補足
あんまり試しすぎないでください。