### PR TITLE
提出関数を定義する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *node_modules/
 /experiment/*.png
 /experiment/*.json
+*.png
+yarn-error.log
+cookie_login.json

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "puppeteer": "^1.7.0",
+    "query-string": "^6.1.0",
     "readline-sync": "^1.4.9"
   },
   "devDependencies": {

--- a/src/submit.js
+++ b/src/submit.js
@@ -26,8 +26,6 @@ const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
   await page.type('textarea[name="sourceCode"]', source_code);
   page.click('#submit');
   await page.waitForNavigation({timeout: 60000, waitUntil: "domcontentloaded"});
-
-  await page.screenshot({path: 'submit_result.png'}); // debug!!!!!!!!
   
   await browser.close();
 }

--- a/src/submit.js
+++ b/src/submit.js
@@ -1,0 +1,50 @@
+const puppeteer = require('puppeteer');
+const queryString = require('query-string')
+const fs = require('fs');
+
+const base_url = 'https://beta.atcoder.jp/contests/'
+const cookie_path = '../cookie_login.json';
+const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
+  const submit_url = `${base_url}${prob}${prob_number}/submit`
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+  const page = await browser.newPage();
+  const cookies = JSON.parse(fs.readFileSync(cookie_path, 'utf-8'));
+  for(let cookie of cookies) await page.setCookie(cookie);
+
+  const navigationPromise = page.waitForNavigation({
+    timeout: 60000, waitUntil: 'domcontentloaded'
+  });
+  await page.goto(submit_url);
+  await navigationPromise;
+  item = await page.$('input[name=csrf_token]');
+  const csrf_token = await (await item.getProperty('value')).jsonValue();
+  console.log(csrf_token)
+
+  const data = {
+    'data.TaskScreenName': `${prob}${prob_number}_${prob_hard}`,
+    'data.LanguageId': lang,
+    'sourceCode': source_code,
+    'csrf_token': csrf_token,
+  }
+
+  await page.setRequestInterception(true);
+  page.on('request', request => {
+    const overrides = {};
+    overrides.method = 'POST';
+    overrides.postData = queryString.stringify(data);
+    request.continue(overrides);
+  });
+  await page.goto(submit_url);
+  // 確認用スクリーンショット
+  await page.screenshot({path: 'sb.png'});
+  
+  await browser.close();
+}
+
+(async() => {
+  await submit('abc', '110', 'a', '3023', 'a = list(map(int, input().split())); print(max(a) * 9 + sum(a))');
+})();
+
+// module.exports = chalk_convert

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,10 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 es6-promise@^4.0.3:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
@@ -189,6 +193,13 @@ puppeteer@^1.7.0:
     rimraf "^2.6.1"
     ws "^5.1.1"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 readable-stream@^2.2.2:
   version "2.3.6"
   resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -214,6 +225,10 @@ rimraf@^2.6.1:
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string_decoder@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
# 概要
#8 
ソースコードを提出する関数を作成しました
引数は、prob: 問題区分(abcとかagcとか), prob_number: 問題番号, prob_hard: 難易度, lang: 言語ID, source_code: ソースコード　という感じになっています

## 変更内容
submit.jsに新しく関数を定義しました
確認用のコードはsubmit_function_debugブランチに分けておきました

## 影響範囲
.gitignoreを少しだけ変更したので、そこぐらいです

## 動作要件
query-stringを新しく追加したので、```yarn install```をお願いします

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
submit_function_debug: expertiment/submit_debug.jsに関数呼び出しのコードが書いてあります

現在書いてある3023はpythonの言語IDです

submit_function_debugで試す際、experimentの中で実行をお願いします
```node submit_debug```
submit_result1.png (提出画面に遷移した時の画像)
submit_result2.png (提出ボタンを押した際の画像)
がそれぞれ出力されます

**!!! 提出に成功すると、atcoderに実際に提出されます !!!**
