### PR TITLE
loginByCookie関数に引数と戻り値をつけた

### DIFF
--- a/experiment/submit_debug.js
+++ b/experiment/submit_debug.js
@@ -1,5 +1,0 @@
-const submit = require("../src/submit")
-const login = require("../src/login")
-
-// login.loginByNameAndPW();
-submit.submit('abc', '110', 'a', '3023', 'a = list(map(int, input().split())); print(max(a) * 9 + sum(a))')

--- a/experiment/submit_debug.js
+++ b/experiment/submit_debug.js
@@ -1,5 +1,5 @@
 const submit = require("../src/submit")
 const login = require("../src/login")
 
-login.loginByNameAndPW();
+// login.loginByNameAndPW();
 submit.submit('abc', '110', 'a', '3023', 'a = list(map(int, input().split())); print(max(a) * 9 + sum(a))')

--- a/experiment/submit_debug.js
+++ b/experiment/submit_debug.js
@@ -1,0 +1,5 @@
+const submit = require("../src/submit")
+const login = require("../src/login")
+
+login.loginByNameAndPW();
+submit.submit('abc', '110', 'a', '3023', 'a = list(map(int, input().split())); print(max(a) * 9 + sum(a))')

--- a/src/login.js
+++ b/src/login.js
@@ -36,9 +36,6 @@ const loginByNameAndPW = async() => {
   // 待つ
   await navigationPromise;
 
-  // ログイン確認用スクリーンショット
-  await page.screenshot({path: "check_login.png"});
-
   // cookie取得
   const cookies = await page.cookies();
   // ファイルに保持
@@ -67,9 +64,6 @@ const loginByCookie = async(url) => {
   await page.goto(url);
 
   await navigationPromise;
-  // 確認用スクリーンショット
-  await page.screenshot({path: "loginByCookie.png"});
-  // await browser.close();
   return [page, browser];
 }
 

--- a/src/login.js
+++ b/src/login.js
@@ -69,8 +69,8 @@ const loginByCookie = async(url) => {
   await navigationPromise;
   // 確認用スクリーンショット
   await page.screenshot({path: "loginByCookie.png"});
-
-  await browser.close();
+  // await browser.close();
+  return [page, browser];
 }
 
 exports.loginByNameAndPW = loginByNameAndPW;

--- a/src/login.js
+++ b/src/login.js
@@ -7,7 +7,6 @@ const rls = require('readline-sync');
 
 const cookie_path = './cookie_login.json';
 const login_url = "https://beta.atcoder.jp/login";
-const atcoder_url = 'https://beta.atcoder.jp/';
 
 
 const loginByNameAndPW = async() => {
@@ -48,7 +47,7 @@ const loginByNameAndPW = async() => {
   await browser.close();
 };
 
-const loginByCookie = async() => {
+const loginByCookie = async(url) => {
   // インスタンス作成
   const browser = await puppeteer.launch({
     args: [
@@ -65,7 +64,7 @@ const loginByCookie = async() => {
   const navigationPromise = page.waitForNavigation({
     timeout: 60000, waitUntil: "domcontentloaded"
   });
-  await page.goto(atcoder_url);
+  await page.goto(url);
 
   await navigationPromise;
   // 確認用スクリーンショット

--- a/src/submit.js
+++ b/src/submit.js
@@ -1,23 +1,17 @@
 const puppeteer = require('puppeteer');
 const queryString = require('query-string')
 const fs = require('fs');
+const login = require('./login')
 
 const base_url = 'https://beta.atcoder.jp/contests/'
 const cookie_path = './cookie_login.json';
 const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
   const submit_url = `${base_url}${prob}${prob_number}/submit`
-  const browser = await puppeteer.launch({
-    args: ['--no-sandbox', '--disable-setuid-sandbox']
-  });
-  const page = await browser.newPage();
-  const cookies = JSON.parse(fs.readFileSync(cookie_path, 'utf-8'));
-  for(let cookie of cookies) await page.setCookie(cookie);
 
-  const navigationPromise = page.waitForNavigation({
-    timeout: 60000, waitUntil: 'domcontentloaded'
-  });
-  await page.goto(submit_url);
-  await navigationPromise;
+  data = await login.loginByCookie(submit_url)
+  page = data[0];
+  browser = data[1];
+
   await page.screenshot({path: 'submit_result1.png'}); // debug!!!!!!!!
 
   const task = `${prob}${prob_number}_${prob_hard}`;
@@ -29,7 +23,7 @@ const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
   await page.waitForNavigation({timeout: 60000, waitUntil: "domcontentloaded"});
 
   await page.screenshot({path: 'submit_result2.png'}); // debug!!!!!!!!
-  
+
   await browser.close();
 }
 

--- a/src/submit.js
+++ b/src/submit.js
@@ -12,8 +12,6 @@ const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
   page = data[0];
   browser = data[1];
 
-  await page.screenshot({path: 'submit_result1.png'}); // debug!!!!!!!!
-
   const task = `${prob}${prob_number}_${prob_hard}`;
   await page.select('select[name="data.TaskScreenName"]', task);
   await page.select('select[name="data.LanguageId"]', lang);
@@ -21,8 +19,6 @@ const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
   await page.type('textarea[name="sourceCode"]', source_code);
   page.click('#submit');
   await page.waitForNavigation({timeout: 60000, waitUntil: "domcontentloaded"});
-
-  await page.screenshot({path: 'submit_result2.png'}); // debug!!!!!!!!
 
   await browser.close();
 }

--- a/src/submit.js
+++ b/src/submit.js
@@ -18,6 +18,7 @@ const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
   });
   await page.goto(submit_url);
   await navigationPromise;
+  await page.screenshot({path: 'submit_result1.png'}); // debug!!!!!!!!
 
   const task = `${prob}${prob_number}_${prob_hard}`;
   await page.select('select[name="data.TaskScreenName"]', task);
@@ -27,7 +28,7 @@ const submit = async(prob, prob_number, prob_hard, lang, source_code) => {
   page.click('#submit');
   await page.waitForNavigation({timeout: 60000, waitUntil: "domcontentloaded"});
 
-  await page.screenshot({path: 'submit_result.png'}); // debug!!!!!!!!
+  await page.screenshot({path: 'submit_result2.png'}); // debug!!!!!!!!
   
   await browser.close();
 }


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#30 
loginByCookie関数に引数と戻り値を与えました。
submit_functionブランチから派生したブランチです。

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
引数urlのページにログインする。戻り値にpage, browserを配列として戻す。(0番目がpage, 1番目がbrowser)

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
submit関数

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
fix_loginByCookieブランチ内で、
experiment内で`atam -l`でログインしておく。
experiment内で`node submt_debug.js`

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
関数を呼び出した側で最後にbrowser.close()をしてあげてください。