### PR TITLE
引数で受け取ったファイルを文字列として取得

### DIFF
--- a/src/atam.js
+++ b/src/atam.js
@@ -2,6 +2,7 @@
 
 const opt = require("./options");
 const mkdotfile = require("./mkdotfile");
+const gets = require("./gets");
 
 let command = opt.args;
 let filename = command[0];

--- a/src/gets.js
+++ b/src/gets.js
@@ -1,6 +1,7 @@
 const puppeteer = require('puppeteer');
 const inquirer = require('inquirer');
 const Fuse = require('fuse.js');
+const fs = require('fs');
 
 const base_url = "https://beta.atcoder.jp/contests/";
 var options = {
@@ -45,4 +46,11 @@ async function get_lang_id(logined_page, prob, prob_number) {
   }).then(answer => langId[answer.lang]);
 }
 
+
+function get_source(source_name) {
+  let source = fs.readFileSync(source_name, 'utf-8');
+  return source;
+}
+
 exports.get_lang_id = get_lang_id;
+exports.get_source = get_source;


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#36 

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
引数で指定したファイルを文字列として返す関数を作成しました。

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
得にはありませんが、src/内のgets.jsに追記してあります。

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
デバッグ用のget_source_debugというbrnachにてatamコマンドで確認が行えるようにしています。

```bash
#get_sorce_debugにcheckoutした状態で
atam 受け取りたいファイル名
```

以上で実行が可能です。

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
得にはありません。