### PR TITLE
cookieの保存場所をホーム直下のdotfile内にする。

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -5,12 +5,14 @@ const puppeteer = require('puppeteer');
 const fs = require('fs');
 const rls = require('readline-sync');
 
-const cookie_path = './cookie_login.json';
+const mkdotfile = require('./mkdotfile');
+
 const login_url = "https://beta.atcoder.jp/login";
+const cookie_path = `${mkdotfile.dotfile_path}/cookie_login.json`;
 const atcoder_url = 'https://beta.atcoder.jp/';
 
-
 const loginByNameAndPW = async() => {
+  mkdotfile.mkdotfile();
   let username = rls.question('username: ');
   let password = rls.question('password: ', {hideEchoBack: true});
 

--- a/src/mkdotfile.js
+++ b/src/mkdotfile.js
@@ -11,7 +11,6 @@ function mkdotfile() {
   catch(e) {
     fs.mkdirSync(dotfile_path);
   }
-  return dotfile_path;
 }
 
 exports.dotfile_path = dotfile_path;

--- a/src/mkdotfile.js
+++ b/src/mkdotfile.js
@@ -2,13 +2,17 @@
 const fs = require('fs');
 const os = require('os');
 
+const dotfile_path = `${os.homedir()}/.atam`;
+
 function mkdotfile() {
   try {
-    let dir = fs.readdirSync(`${os.homedir()}/.atam`);
+    let dir = fs.readdirSync(dotfile_path);
   }
   catch(e) {
-    fs.mkdirSync(`${os.homedir()}/.atam`);
+    fs.mkdirSync(dotfile_path);
   }
+  return dotfile_path;
 }
 
-module.exports = mkdotfile;
+exports.dotfile_path = dotfile_path;
+exports.mkdotfile = mkdotfile;


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#26 
## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
`atam -l`の際に、cookieをdotfile内に作るように修正しました。
## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
cookieを利用するファイル
## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
とくになし
## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
ホーム直下に`.atam`ができていて、かつその中にcookieが保存されているか。