### PR TITLE
versionをpackage.jsonから参照

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-var program = require('commander');
+const program = require('commander');
 const login = require('./login');
+const package = require('../package.json')
 
 program
-  .version('0.0.1')
+  .version(package.version)
   .usage('<filename> <prob(e.g.: abc)> <number(e.g.: 001)>')
   .option('-l,  --login', 'Login AtCoder')
   .parse(process.argv);


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
version表記が直打ちだったので、package.jsonを参照するように変更
バージョンの管理を行う際、npmの機能を使うと自動でpackage.jsonの中身が変わるので、それを使っていくといいと思います
```
npm version major
```
とか

上記をやると勝手にコミットされます

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
helpに表示されるバージョン（現状0.0.0）

```
atam --version
```

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
とても狭い変更のため、特に無いです

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
