### PR TITLE
ログイン失敗時の処理を追加

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -11,20 +11,25 @@ const login_url = "https://beta.atcoder.jp/login";
 const cookie_path = `${mkdotfile.dotfile_path}/cookie_login.json`;
 
 const loginByNameAndPW = async() => {
-  mkdotfile.mkdotfile();
-  let username = rls.question('username: ');
-  let password = rls.question('password: ', {hideEchoBack: true});
-
-  // インスタンス作成
   const browser = await puppeteer.launch({
     args: [
-    '--no-sandbox',
-    '--disable-setuid-sandbox'
+      '--no-sandbox',
+      '--disable-setuid-sandbox'
     ]
   });
   const page = await browser.newPage();
-  await page.goto(login_url);
 
+  try {
+    await page.goto(login_url);
+  } catch (e) {
+    console.log(e);
+    console.log('check network connection.');
+    browser.close();
+    return;
+  }
+
+  let username = rls.question('username: ');
+  let password = rls.question('password: ', {hideEchoBack: true});
   // usename欄にusername書いて
   await page.type('input[name="username"]', username);
   // password欄にpassword書いて
@@ -37,9 +42,6 @@ const loginByNameAndPW = async() => {
   await page.click('#submit');
   // 待つ
   await navigationPromise;
-
-  // ログイン確認用スクリーンショット
-  await page.screenshot({path: "check_login.png"});
 
   // cookie取得
   const cookies = await page.cookies();
@@ -68,3 +70,4 @@ const loginByCookie = async() => {
 
 exports.loginByNameAndPW = loginByNameAndPW;
 exports.loginByCookie = loginByCookie;
+

--- a/src/login.js
+++ b/src/login.js
@@ -42,10 +42,11 @@ const loginByNameAndPW = async() => {
   const url_after_logging = await page['_target']['_targetInfo']['title'];
 
   if(url_after_logging == login_url){
-    console.log('Error! Wrong username or password!');
+    console.log('Error! Wrong username or password.');
     await browser.close();
     return;
   }
+  else console.log('Complete login!!');
   // cookie取得
   const cookies = await page.cookies();
   fs.writeFileSync(cookie_path, JSON.stringify(cookies));

--- a/src/login.js
+++ b/src/login.js
@@ -30,29 +30,30 @@ const loginByNameAndPW = async() => {
 
   let username = rls.question('username: ');
   let password = rls.question('password: ', {hideEchoBack: true});
-  // usename欄にusername書いて
   await page.type('input[name="username"]', username);
-  // password欄にpassword書いて
   await page.type('input[name="password"]', password);
   // 60000msでタイムアウトし、ページが遷移するまで待機する設定
   const navigationPromise = page.waitForNavigation({
     timeout: 60000, waitUntil: "domcontentloaded"
   });
-  // ログインをクリック
   await page.click('#submit');
   // 待つ
   await navigationPromise;
+  const url_after_logging = await page['_target']['_targetInfo']['title'];
 
+  if(url_after_logging == login_url){
+    console.log('Error! Wrong username or password!');
+    await browser.close();
+    return;
+  }
   // cookie取得
   const cookies = await page.cookies();
-  // ファイルに保持
   fs.writeFileSync(cookie_path, JSON.stringify(cookies));
 
   await browser.close();
 };
 
 const loginByCookie = async() => {
-  // インスタンス作成
   const browser = await puppeteer.launch({
     args: [
     '--no-sandbox',
@@ -65,8 +66,10 @@ const loginByCookie = async() => {
   const cookies = JSON.parse(fs.readFileSync(cookie_path, 'utf-8'));
   for(let cookie of cookies) await page.setCookie(cookie);
 
+  browser.close();
   return [page, browser];
 }
+
 
 exports.loginByNameAndPW = loginByNameAndPW;
 exports.loginByCookie = loginByCookie;


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#25 
ネットワークに繋がってないときとユーザーネーム・パスワードが間違ってるときの処理を追加しました。
## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
loginByNameAndPW関数。
## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
```atam -l```で最初にログインするとき。
## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
とくになし。
## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
ネットワークに繋がってないときと、ユーザーネーム・パスワードが間違っているときにエラーが出るか。