### PR TITLE
eslint branchに関して、for-ofの削除

### DIFF
--- a/src/gets.js
+++ b/src/gets.js
@@ -35,11 +35,12 @@ async function get_lang_id(logined_page, prob, prob_number) {
 
   const items = await logined_page.$$('select[name="data.LanguageId"] option');
   const langId = {};
-  for (const item of items) {
+  await logined_page.screenshot({path: "lg.png"})
+  await Promise.all(items.map(async item => {
     const id = await (await item.getProperty('value')).jsonValue();
     const lang = await (await item.getProperty('textContent')).jsonValue();
     langId[lang] = id;
-  }
+  }));
 
 
   const language = Object.keys(langId).map(elm => ({ lang: elm }));
@@ -67,12 +68,11 @@ async function get_problem_id(logined_page, prob, prob_number) {
 
   const items = await logined_page.$$('select[name="data.TaskScreenName"] option');
   const TaskScreenName = {};
-  for (const item of items) {
+  await Promise.all(items.map(async item => {
     const id = await (await item.getProperty('value')).jsonValue();
     const problem = await (await item.getProperty('textContent')).jsonValue();
     TaskScreenName[problem] = id;
-  }
-
+  }));
 
   const Task = Object.keys(TaskScreenName).map(elm => ({ problem: elm }));
 

--- a/src/gets.js
+++ b/src/gets.js
@@ -35,7 +35,6 @@ async function get_lang_id(logined_page, prob, prob_number) {
 
   const items = await logined_page.$$('select[name="data.LanguageId"] option');
   const langId = {};
-  await logined_page.screenshot({path: "lg.png"})
   await Promise.all(items.map(async item => {
     const id = await (await item.getProperty('value')).jsonValue();
     const lang = await (await item.getProperty('textContent')).jsonValue();

--- a/src/login.js
+++ b/src/login.js
@@ -66,7 +66,7 @@ const loginByCookie = async () => {
 
   // cookiesの読み込み
   const cookies = JSON.parse(fs.readFileSync(cookie_path, 'utf-8'));
-  for (const cookie of cookies) await page.setCookie(cookie);
+  await page.setCookie(...cookies);
 
   return [page, browser];
 };


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
awaitを使う際に、foreachが使えないようなので別の方法を模索

sync/await用のループ方法があるらしい(Promise.all)

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

* logins.js
  - cookieを設定するときにまとめて設定できたので、それに変更
* gets.js
  - for-ofに関してPromise.allを使うように変更

提出コマンドを打ってみて、言語選択が正しく出てくればおkかなという感じで確認していました

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
* 保存されているcookieを使ったログイン処理
* 提出時の言語選択、問題選択

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
確認する際に、正常にログインを完了しておいてください

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
