### PR TITLE
提出の成否を表示

### DIFF
--- a/src/submit.js
+++ b/src/submit.js
@@ -2,9 +2,10 @@ const puppeteer = require('puppeteer');
 const queryString = require('query-string');
 const fs = require('fs');
 const login = require('./login');
+const color = require('./message_color');
 
 const baseUrl = 'https://beta.atcoder.jp/contests/';
-const cookiePath = './cookieLogin.json';
+const submissionsUrl = 'submissions/me';
 const submit = async (loginedPage, prob, probNumber, task, lang, sourceCode) => {
   const submitUrl = `${baseUrl}${prob}${probNumber}/submit`;
   const page = loginedPage;
@@ -15,16 +16,19 @@ const submit = async (loginedPage, prob, probNumber, task, lang, sourceCode) => 
   await page.goto(submitUrl);
   await navigationPromise;
 
-  await page.screenshot({ path: 'submit_result1.png' }); // debug!!!!!!!!
-
   await page.select('select[name="data.TaskScreenName"]', task);
   await page.select('select[name="data.LanguageId"]', lang);
   await page.click('button.btn-toggle-editor');
   await page.type('textarea[name="sourceCode"]', sourceCode);
+
   page.click('#submit');
   await page.waitForNavigation({ timeout: 60000, waitUntil: 'domcontentloaded' });
-
-  await page.screenshot({ path: 'submit_result2.png' }); // debug!!!!!!!!
+  if(page.url().endsWith(submissionsUrl)){
+    console.log(color.success('提出が完了しました'));
+  } else {
+    console.log(color.error('提出できませんでした'));
+  }
+  console.log('url: ' + await page.url())
 };
 
 exports.submit = submit;


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#56 
提出の成功・失敗を文字で出します。

エラー内容（提出失敗理由？）も取得しようかと思ったのですが、うまく取れなかった上にあんまり重要じゃない気がしたので一先ずこれで出しています。

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* 提出時にpngが保存されなくなりました。
* 提出に成功した場合はsuccess色で、失敗した場合はerror色でメッセージを出します。
* 成功失敗判定はurlを使っています。submissions/meに飛べたら🙆‍♂️みたいな

中身のあるファイルで提出 / 空のファイルで提出　で確認をしていました。

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
提出時

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
提出する際にはあらかじめログインをしておいてください

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
