### PR TITLE
コマンドを使うように変更(commander)

### DIFF
--- a/src/atam.js
+++ b/src/atam.js
@@ -1,33 +1,7 @@
 #!/usr/bin/env node
 
 const opt = require('./options');
-// const mkdotfile = require('./mkdotfile');
-const gets = require('./gets');
-const login = require('./login');
-const { submit } = require('./submit');
 
-const command = opt.args;
-const filename = command[0];
-const prob = command[1];
-const number = command[2];
-
-
-(async () => {
-  if (opt.login) {
-    login.loginByNameAndPW();
-    return;
-  }
-  if (filename && prob && number) {
-    const data = await login.loginByCookie();
-    const page = data[0];
-    const browser = data[1];
-
-    const sourceCode = gets.getSource(filename);
-    const lang = await gets.getLangId(page, prob, number);
-    const task = await gets.getProblemId(page, prob, number);
-    await submit(page, prob, number, task, lang, sourceCode);
-    browser.close();
-  } else {
-    opt.outputHelp();
-  }
-})();
+if (opt.args.length === 0) {
+  opt.outputHelp();
+}

--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -1,0 +1,39 @@
+// const utils = require('./utils');
+// const gets = require('./gets');
+const loginMod = require('./login');
+const submitMod = require('./submit');
+const gets = require('./gets');
+//
+// async function sampleCase(prob, number, ...commands) {
+//   const task = 'abc001_1';
+//   const [browser, page] = await utils.createBrowser();
+//   const samples = await gets.getSamples(page, prob, number, task);
+//   // samples.each(() => {
+//   //   console.log(this);
+//   // });
+//
+//   browser.close();
+// }
+//
+// async function test() {
+//   console.log("this is test");
+// }
+
+async function login() {
+  loginMod.loginByNameAndPW();
+}
+
+async function submit(filename, prob, number) {
+  const [page, browser] = await loginMod.loginByCookie();
+
+  const sourceCode = gets.getSource(filename);
+  const lang = await gets.getLangId(page, prob, number);
+  const task = await gets.getProblemId(page, prob, number);
+  await submitMod.submit(page, prob, number, task, lang, sourceCode);
+  browser.close();
+}
+
+module.exports = {
+  login,
+  submit,
+};

--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -1,23 +1,6 @@
-// const utils = require('./utils');
-// const gets = require('./gets');
 const loginMod = require('./login');
 const submitMod = require('./submit');
 const gets = require('./gets');
-//
-// async function sampleCase(prob, number, ...commands) {
-//   const task = 'abc001_1';
-//   const [browser, page] = await utils.createBrowser();
-//   const samples = await gets.getSamples(page, prob, number, task);
-//   // samples.each(() => {
-//   //   console.log(this);
-//   // });
-//
-//   browser.close();
-// }
-//
-// async function test() {
-//   console.log("this is test");
-// }
 
 async function login() {
   loginMod.loginByNameAndPW();

--- a/src/login.js
+++ b/src/login.js
@@ -1,25 +1,19 @@
 #!/usr/bin/env node
 
-const puppeteer = require('puppeteer');
 const fs = require('fs');
 const rls = require('readline-sync');
 
 const consts = require('./consts');
 const mkdotfile = require('./mkdotfile');
 const color = require('./message_color');
+const utils = require('./utils');
 
 const loginUrl = `${consts.atcoderUrl}/login`;
 const cookiePath = `${mkdotfile.dotfilePath}/cookieLogin.json`;
 
 const loginByNameAndPW = async () => {
   mkdotfile.mkdotfile();
-  const browser = await puppeteer.launch({
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-    ],
-  });
-  const page = await browser.newPage();
+  const [page, browser] = await utils.createBrowser();
 
   try {
     await page.goto(loginUrl);
@@ -61,13 +55,7 @@ const loginByNameAndPW = async () => {
 };
 
 const loginByCookie = async () => {
-  const browser = await puppeteer.launch({
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-    ],
-  });
-  const page = await browser.newPage();
+  const [page, browser] = await utils.createBrowser();
 
   // cookiesの読み込み
   let cookies;

--- a/src/options.js
+++ b/src/options.js
@@ -1,12 +1,48 @@
 #!/usr/bin/env node
 
 const program = require('commander');
+
+const actions = require('./command_actions');
+const utils = require('./utils');
+
 const packageJson = require('../package.json');
 
 program
   .version(packageJson.version)
-  .usage('<filename> <prob(e.g.: abc)> <number(e.g.: 001)>')
-  .option('-l,  --login', 'Login AtCoder')
+  .usage('<command> -h');
+
+program
+  .command('login')
+  .alias('l')
+  .description('Login AtCoder')
+  .action(actions.login)
+  .on('--help', () => {
+    utils.helpMessage({
+      example: [
+        'login', 'l',
+      ],
+    });
+  });
+
+program
+  .command('submit <filename> <prob> <number>')
+  .alias('s')
+  .description('Submit your code')
+  .action(actions.submit)
+  .on('--help', () => {
+    utils.helpMessage({
+      message: [
+        'prob (e.g.: abc)',
+        'number (e.g.: 001)',
+      ],
+      example: [
+        'submit abc 001 main.js',
+        's abc 011 main.py',
+      ],
+    });
+  });
+
+program
   .parse(process.argv);
 
 module.exports = program;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,29 @@
+const puppeteer = require('puppeteer');
+
+async function createBrowser() {
+  const browser = await puppeteer.launch({
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+    ],
+  });
+  const page = await browser.newPage();
+  return [page, browser];
+}
+
+function helpMessage({ message, example }) {
+  if (message) {
+    console.log();
+    message.forEach(e => console.log(e));
+  }
+  if (example) {
+    console.log('\nExamples:\n');
+    example.forEach(e => console.log(`  'atam ${e}'`));
+  }
+  console.log();
+}
+
+module.exports = {
+  createBrowser,
+  helpMessage,
+};


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
オプションを使って分けていましたが、コマンドを使って分けた方が書きやすいような気がしたので試しに変更してみました

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
コマンド実行周りが全体的に変更されました
見えるところだと`atam -l`とかが`atam l`に
それに伴いhelpも少し変更しています

ついでにコードが重複していた箇所をutilsにまとめました

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
関数の中身自体はそのまま引っ張ってきたので特に問題なく動くはずです
一応、ログインからの提出の流れは確認しています

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
提出が今まで、`atam main.js abc 001`とかだったのですが`atam submit abc 001`とかになりました