### PR TITLE
サンプルケース確認コマンドを実装

### DIFF
--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -1,6 +1,10 @@
+const childProcess = require('child_process');
+
 const loginMod = require('./login');
 const submitMod = require('./submit');
 const gets = require('./gets');
+const utils = require('./utils');
+const color = require('./message_color');
 
 async function login() {
   loginMod.loginByNameAndPW();
@@ -16,7 +20,50 @@ async function submit(filename, prob, number) {
   browser.close();
 }
 
+function execSampleCase(commands, input, output) {
+  return new Promise((resolve) => {
+    const proc = childProcess.spawn(commands[0], commands.slice(1), {
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    proc.stdin.write(input);
+    proc.stdin.end();
+    let execResult = '';
+    proc.stdout.on('data', (data) => {
+      execResult += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      let answer = 0;
+      if (code === 0) {
+        process.stdout.write(execResult);
+        process.stdout.write(color.success(output));
+        answer = Number(execResult === output);
+      } else {
+        process.stdout.write(execResult);
+        answer = 2;
+      }
+      const message = [
+        color.warning('WA'),
+        color.success('AC'),
+        color.warning('RE'),
+      ];
+      console.log(`==============  ${message[answer]}`);
+      resolve(execResult);
+    });
+  });
+}
+
+async function sample(prob, number, commands) {
+  const [page, browser] = await loginMod.loginByCookie();
+  const task = await gets.getProblemId(page, prob, number);
+  const samples = await gets.getSamples(page, prob, number, task);
+  utils.syncMap(samples, value => execSampleCase(commands, ...value));
+
+  browser.close();
+}
+
 module.exports = {
   login,
   submit,
+  sample,
 };

--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -10,7 +10,7 @@ async function login() {
   loginMod.loginByNameAndPW();
 }
 
-async function submit(filename, prob, number) {
+async function submit(prob, number, filename) {
   const [page, browser] = await loginMod.loginByCookie();
 
   const sourceCode = gets.getSource(filename);

--- a/src/gets.js
+++ b/src/gets.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const autocompletePrompt = require('inquirer-autocomplete-prompt');
 
 const consts = require('./consts');
+const utils = require('./utils');
 
 const baseUrl = `${consts.atcoderUrl}/contests/`;
 const langIdOptions = {
@@ -29,6 +30,24 @@ const problemIdOptions = {
     'problem',
   ],
 };
+
+async function getSamples(page, prob, probNumber, task) {
+  const url = `${baseUrl}${prob}${probNumber}/tasks/${task}`;
+
+  await page.goto(url);
+
+  let samples = await page.$$('pre[id^="pre-sample"]');
+  if (samples.length === 0) {
+    samples = await page.$$('pre[id^="for_copy"]');
+  }
+
+  const results = await utils.syncMap(samples,
+    async value => (await value.getProperty('textContent')).jsonValue());
+  const sampleCase = Array.from({
+    length: results.length / 2,
+  }).map((v, i) => [results[i * 2], results[i * 2 + 1]]);
+  return sampleCase; // input, output
+}
 
 async function getLangId(loginedPage, prob, probNumber) {
   const url = `${baseUrl}${prob}${probNumber}/submit`;
@@ -99,6 +118,9 @@ function getSource(sourceName) {
 }
 
 
-exports.getLangId = getLangId;
-exports.getProblemId = getProblemId;
-exports.getSource = getSource;
+module.exports = {
+  getLangId,
+  getProblemId,
+  getSource,
+  getSamples,
+};

--- a/src/options.js
+++ b/src/options.js
@@ -25,6 +25,23 @@ program
   });
 
 program
+  .command('sample <prob> <number> [commands...]')
+  .description('Check sample case')
+  .action(actions.sample)
+  .on('--help', () => {
+    utils.helpMessage({
+      message: [
+        'prob (e.g.: abc)',
+        'number (e.g.: 001)',
+        'commands (e.g.: python main.py)',
+      ],
+      example: [
+        'sample abc 001 main.js',
+      ],
+    });
+  });
+
+program
   .command('submit <filename> <prob> <number>')
   .alias('s')
   .description('Submit your code')

--- a/src/options.js
+++ b/src/options.js
@@ -25,7 +25,8 @@ program
   });
 
 program
-  .command('sample <prob> <number> [commands...]')
+  .command('test <prob> <number> [commands...]')
+  .alias('t')
   .description('Check sample case')
   .action(actions.sample)
   .on('--help', () => {
@@ -36,13 +37,15 @@ program
         'commands (e.g.: python main.py)',
       ],
       example: [
-        'sample abc 001 main.js',
+        'test abc 001 node main.js',
+        'test abc 010 ./a.out',
+        't abc 011 python main.py',
       ],
     });
   });
 
 program
-  .command('submit <filename> <prob> <number>')
+  .command('submit <prob> <number> <filename>')
   .alias('s')
   .description('Submit your code')
   .action(actions.submit)

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,31 @@ function helpMessage({ message, example }) {
   console.log();
 }
 
+async function syncEach(array, f) {
+  const createFunc = value => () => f(value);
+  let tmp = { then: dummy => dummy() };
+  while (array.length !== 0) {
+    tmp = tmp.then(createFunc(array.shift()));
+  }
+  await tmp;
+}
+
+async function syncMap(array, f) {
+  const result = [];
+  const createFunc = value => (ret) => {
+    result.push(ret);
+    return f(value);
+  };
+  let tmp = { then: dummy => dummy() };
+  while (array.length !== 0) {
+    tmp = tmp.then(createFunc(array.shift()));
+  }
+  return tmp.then(ret => result.slice(1).concat(ret));
+}
+
 module.exports = {
   createBrowser,
   helpMessage,
+  syncEach,
+  syncMap,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,11 +25,11 @@ function helpMessage({ message, example }) {
 
 async function syncEach(array, f) {
   const createFunc = value => () => f(value);
-  let tmp = { then: dummy => dummy() };
+  let prev = Promise.resolve();
   while (array.length !== 0) {
-    tmp = tmp.then(createFunc(array.shift()));
+    prev = prev.then(createFunc(array.shift()));
   }
-  await tmp;
+  await prev;
 }
 
 async function syncMap(array, f) {
@@ -38,11 +38,11 @@ async function syncMap(array, f) {
     result.push(ret);
     return f(value);
   };
-  let tmp = { then: dummy => dummy() };
+  let prev = Promise.resolve();
   while (array.length !== 0) {
-    tmp = tmp.then(createFunc(array.shift()));
+    prev = prev.then(createFunc(array.shift()));
   }
-  return tmp.then(ret => result.slice(1).concat(ret));
+  return prev.then(ret => result.slice(1).concat(ret));
 }
 
 module.exports = {


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#23 テストケースにあってるか確認する
激しく欲しかったので作りました

`atam sample --help`

`atam sample abc 001 python main.py`とかでチェックできます

お手元環境にサンプルケースを投げつけるといった感じで実装しました
実行時間も載せたかったのですが、nodeのオーバーヘッドが激しくてうまく実装できませんでした

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* サンプルケース確認コマンドを実装
* ヘルプにこのコマンドについて追加

* utils
  - awaitをループさせたかったので規約に触れないように実装 (syncEach, syncMap)

* gets
  - サンプルケースを取得する関数追加 (getSamples)

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
新規追加のみ

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
ログインしておいてください

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
