### PR TITLE
ページ遷移からのwaitForNavigationを撲滅する

### DIFF
--- a/src/gets.js
+++ b/src/gets.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const autocompletePrompt = require('inquirer-autocomplete-prompt');
 
 const consts = require('./consts');
+const utils = require('./utils');
 
 const baseUrl = `${consts.atcoderUrl}/contests/`;
 const langIdOptions = {
@@ -33,7 +34,7 @@ const problemIdOptions = {
 async function getLangId(loginedPage, prob, probNumber) {
   const url = `${baseUrl}${prob}${probNumber}/submit`;
 
-  await loginedPage.goto(url);
+  await utils.waitFor(loginedPage, p => p.goto(url));
 
   const items = await loginedPage.$$('select[name="data.LanguageId"] option');
   const langId = {};
@@ -65,7 +66,7 @@ async function getLangId(loginedPage, prob, probNumber) {
 async function getProblemId(loginedPage, prob, probNumber) {
   const url = `${baseUrl}${prob}${probNumber}/submit`;
 
-  await loginedPage.goto(url);
+  await utils.waitFor(loginedPage, p => p.goto(url));
 
   const items = await loginedPage.$$('select[name="data.TaskScreenName"] option');
   const TaskScreenName = {};

--- a/src/login.js
+++ b/src/login.js
@@ -16,7 +16,7 @@ const loginByNameAndPW = async () => {
   const [page, browser] = await utils.createBrowser();
 
   try {
-    await page.goto(loginUrl);
+    await utils.waitFor(page, p => p.goto(loginUrl));
   } catch (e) {
     console.log(color.error('check network connection.'));
     browser.close();
@@ -27,13 +27,7 @@ const loginByNameAndPW = async () => {
   const password = rls.question('password: ', { hideEchoBack: true });
   await page.type('input[name="username"]', username);
   await page.type('input[name="password"]', password);
-  // 60000msでタイムアウトし、ページが遷移するまで待機する設定
-  const navigationPromise = page.waitForNavigation({
-    timeout: 60000, waitUntil: 'domcontentloaded',
-  });
-  await page.click('#submit');
-  // 待つ
-  await navigationPromise;
+  await utils.waitFor(page, p => p.click('#submit'));
 
   // 要素にアンダースコアが入っているので仕方なし
   /* eslint no-underscore-dangle:

--- a/src/submit.js
+++ b/src/submit.js
@@ -1,6 +1,7 @@
 const color = require('./message_color');
 
 const consts = require('./consts');
+const utils = require('./utils');
 
 const submissionsUrl = 'submissions/me';
 const baseUrl = `${consts.atcoderUrl}/contests/`;
@@ -9,19 +10,14 @@ const submit = async (loginedPage, prob, probNumber, task, lang, sourceCode) => 
   const submitUrl = `${baseUrl}${prob}${probNumber}/submit`;
   const page = loginedPage;
 
-  const navigationPromise = page.waitForNavigation({
-    timeout: 60000, waitUntil: 'domcontentloaded',
-  });
-  await page.goto(submitUrl);
-  await navigationPromise;
+  await utils.waitFor(page, p => p.goto(submitUrl));
 
   await page.select('select[name="data.TaskScreenName"]', task);
   await page.select('select[name="data.LanguageId"]', lang);
   await page.click('button.btn-toggle-editor');
   await page.type('textarea[name="sourceCode"]', sourceCode);
 
-  page.click('#submit');
-  await page.waitForNavigation({ timeout: 60000, waitUntil: 'domcontentloaded' });
+  await utils.waitFor(page, p => p.click('#submit'));
   if (page.url().endsWith(submissionsUrl)) {
     console.log(color.success('提出が完了しました'));
   } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,15 @@ function helpMessage({ message, example }) {
   console.log();
 }
 
+async function waitFor(page, func) {
+  await Promise.all([
+    func(page),
+    page.waitForNavigation({ timeout: 60000, waitUntil: 'domcontentloaded' }),
+  ]);
+}
+
 module.exports = {
   createBrowser,
   helpMessage,
+  waitFor,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,7 @@ async function waitFor(page, func) {
   await Promise.all([
     func(page),
     page.waitForNavigation({ timeout: 60000, waitUntil: 'domcontentloaded' }),
-  ])
+  ]);
 }
 
 async function syncEach(array, f) {


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
```
page.waitForNavigation({ timeout: 60000, waitUntil: 'domcontentloaded' }),
```
のパラメータとか使い方とか紹介サイト毎に違うので一元管理しておきたいなと思った次第です

https://qiita.com/hnw/items/a07e6b88d95d1656e02f
の記事の一番上で紹介されている書き方にしています

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* utilsに新しく関数を追加しました
waitFor: pageとpageに対する操作を引数にしています

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
ところどころwaitForNavigationを使っていない場所があったのでそこに影響が出るかもしれません
意図してなのか入れ忘れなのかもはやわからないので全部置き換えておきました

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
