### PR TITLE
ディレクトリの作成

### DIFF
--- a/experiment/http_request.js
+++ b/experiment/http_request.js
@@ -1,0 +1,58 @@
+const urlLib = require('url');
+const puppeteer = require('puppeteer');
+const https = require('https');
+const cheerio = require('cheerio');
+const fs = require('fs');
+
+const color = require('../src/message_color');
+const mkdotfile = require('../src/mkdotfile');
+const cookiePath = `${mkdotfile.dotfilePath}/cookieLogin.json`;
+
+// const utils = require('../src/utils');
+
+function getRequest(url, callback) {
+  let cookies = null;
+  try {
+    cookies = JSON.parse(fs.readFileSync(cookiePath, 'utf-8'));
+  } catch (e) {
+    console.log(color.error('Error!! Faild login.'));
+    console.log('Try "atam -l"');
+    process.exit(1);
+  }
+  let cookie = cookies.map(e => `${e.name}=${e.value}`);
+  let headers = { cookie };
+
+  return new Promise(resolve => {
+    let parsedUrl = new URL(url)
+    console.log(parsedUrl.pathname)
+    let req = https.request({hostname: parsedUrl.hostname, path: parsedUrl.pathname, headers}, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => resolve(callback(data)));
+    })
+
+    req.end();
+  });
+}
+
+const url = 'https://atcoder.jp/contests/abs/submissions/me';
+
+(async () => {
+  let data = await getRequest(url, data => {
+    const $ = cheerio.load(data);
+    const contests = $('#select-task option')
+      .map((i, e) => {
+        const elm = $(e);
+        return {
+          value: elm.attr('value'),
+          text: elm.text()
+        };
+      })
+      .filter((i, e) => e.value !== '');
+    return contests.get();
+  });
+  console.log(data);
+})()

--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -5,6 +5,7 @@ const submitMod = require('./submit');
 const gets = require('./gets');
 const utils = require('./utils');
 const color = require('./message_color');
+const dirTree = require('./dir_tree');
 
 async function login() {
   loginMod.loginByNameAndPW();
@@ -62,17 +63,13 @@ async function sample(prob, commands) {
   browser.close();
 }
 
-async function createDirTree(prob) {
-  const [page, browser] = await loginMod.loginByCookie();
-  const task = await gets.getProblemIds(page, prob);
-  const taskIds = Object.values(task);
-  console.log(taskIds);
-  browser.close();
+async function createDirTreeCmd(prob) {
+  dirTree.createDirTree(prob);
 }
 
 module.exports = {
   login,
   submit,
   sample,
-  createDirTree,
+  createDirTreeCmd,
 };

--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -62,8 +62,17 @@ async function sample(prob, commands) {
   browser.close();
 }
 
+async function createDirTree(prob) {
+  const [page, browser] = await loginMod.loginByCookie();
+  const task = await gets.getProblemIds(page, prob);
+  const taskIds = Object.values(task);
+  console.log(taskIds);
+  browser.close();
+}
+
 module.exports = {
   login,
   submit,
   sample,
+  createDirTree,
 };

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,7 +1,8 @@
-const atcoderUrl = 'https://atcoder.jp';
-
-// more
+const mkdotfile = require('./mkdotfile');
 
 module.exports = {
-  atcoderUrl,
+  atcoderUrl: 'https://atcoder.jp',
+  cookiePath: `${mkdotfile.dotfilePath}/cookieLogin.json`,
+
+  // more
 };

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,8 +1,11 @@
-const mkdotfile = require('./mkdotfile');
+const os = require('os');
 
+const dotfilePath = `${os.homedir()}/.atam`;
 module.exports = {
+  dotfilePath,
   atcoderUrl: 'https://atcoder.jp',
-  cookiePath: `${mkdotfile.dotfilePath}/cookieLogin.json`,
+  cookiePath: `${dotfilePath}/cookieLogin.json`,
+  dirTreeConf: '.atam.json',
 
   // more
 };

--- a/src/consts.js
+++ b/src/consts.js
@@ -5,7 +5,6 @@ module.exports = {
   dotfilePath,
   atcoderUrl: 'https://atcoder.jp',
   cookiePath: `${dotfilePath}/cookieLogin.json`,
-  dirTreeConf: '.atam.json',
 
   // more
 };

--- a/src/dir_tree.js
+++ b/src/dir_tree.js
@@ -1,14 +1,9 @@
-const fs = require('fs');
-const path = require('path');
-
 const utils = require('./utils');
 const gets = require('./gets');
-const consts = require('./consts');
 const color = require('./message_color');
 
 async function createDirTree(prob) {
   const root = `./${prob}`;
-  const confPath = `${root}/${consts.dirTreeConf}`;
 
   if (utils.mkdirIfNotExists(root)) {
     console.log(color.success(`create ${root}/`));
@@ -28,27 +23,8 @@ async function createDirTree(prob) {
       console.log(color.success(`create ${dir}`));
     }
   });
-
-  const conf = {
-    prob,
-    dirMap,
-  };
-  fs.writeFileSync(confPath, JSON.stringify(conf));
-}
-
-function findRoot(root) {
-  if (fs.existsSync(`${root}/${consts.dirTreeConf}`)) {
-    return root;
-  }
-
-  if (root !== '/') {
-    return findRoot(path.resolve(root, '..'));
-  }
-
-  return null;
 }
 
 module.exports = {
   createDirTree,
-  findRoot,
 };

--- a/src/dir_tree.js
+++ b/src/dir_tree.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+
+const utils = require('./utils');
+const gets = require('./gets');
+const consts = require('./consts');
+const color = require('./message_color');
+
+async function createDirTree(prob) {
+  const root = `./${prob}`;
+  const confPath = `${root}/${consts.dirTreeConf}`;
+
+  utils.mkdirIfNotExists(root);
+
+  const task = await gets.getProblemIds(prob);
+  const dirMap = {};
+  const taskIds = Object.values(task).map((e, i) => {
+    const dirName = String.fromCharCode(97 + i); // 97 is a
+    dirMap[dirName] = e;
+    return dirName;
+  });
+
+  taskIds.forEach((dirName) => {
+    const path = `${root}/${dirName}`;
+    utils.mkdirIfNotExists(path);
+  });
+
+  const conf = {
+    prob,
+    dirMap,
+  };
+  fs.writeFileSync(confPath, JSON.stringify(conf));
+  console.log(color.success(`create ${prob}/`));
+}
+
+module.exports = {
+  createDirTree,
+};

--- a/src/dir_tree.js
+++ b/src/dir_tree.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 const utils = require('./utils');
 const gets = require('./gets');
@@ -9,7 +10,9 @@ async function createDirTree(prob) {
   const root = `./${prob}`;
   const confPath = `${root}/${consts.dirTreeConf}`;
 
-  utils.mkdirIfNotExists(root);
+  if (utils.mkdirIfNotExists(root)) {
+    console.log(color.success(`create ${root}/`));
+  }
 
   const task = await gets.getProblemIds(prob);
   const dirMap = {};
@@ -20,8 +23,10 @@ async function createDirTree(prob) {
   });
 
   taskIds.forEach((dirName) => {
-    const path = `${root}/${dirName}`;
-    utils.mkdirIfNotExists(path);
+    const dir = `${root}/${dirName}`;
+    if (utils.mkdirIfNotExists(dir)) {
+      console.log(color.success(`create ${dir}`));
+    }
   });
 
   const conf = {
@@ -29,9 +34,21 @@ async function createDirTree(prob) {
     dirMap,
   };
   fs.writeFileSync(confPath, JSON.stringify(conf));
-  console.log(color.success(`create ${prob}/`));
+}
+
+function findRoot(root) {
+  if (fs.existsSync(`${root}/${consts.dirTreeConf}`)) {
+    return root;
+  }
+
+  if (root !== '/') {
+    return findRoot(path.resolve(root, '..'));
+  }
+
+  return null;
 }
 
 module.exports = {
   createDirTree,
+  findRoot,
 };

--- a/src/login.js
+++ b/src/login.js
@@ -1,15 +1,12 @@
-#!/usr/bin/env node
-
 const fs = require('fs');
 const rls = require('readline-sync');
 
 const consts = require('./consts');
-const mkdotfile = require('./mkdotfile');
 const color = require('./message_color');
 const utils = require('./utils');
 
 const loginUrl = `${consts.atcoderUrl}/login`;
-const cookiePath = `${mkdotfile.dotfilePath}/cookieLogin.json`;
+const mkdotfile = require('./mkdotfile');
 
 const loginByNameAndPW = async () => {
   mkdotfile.mkdotfile();
@@ -43,29 +40,23 @@ const loginByNameAndPW = async () => {
   }
   // cookie取得
   const cookies = await page.cookies();
-  fs.writeFileSync(cookiePath, JSON.stringify(cookies));
+  fs.writeFileSync(consts.cookiePath, JSON.stringify(cookies));
 
   await browser.close();
 };
 
 const loginByCookie = async () => {
-  const [page, browser] = await utils.createBrowser();
-
   // cookiesの読み込み
-  let cookies;
-  try {
-    cookies = JSON.parse(fs.readFileSync(cookiePath, 'utf-8'));
-  } catch (e) {
-    console.log(color.error('Error!! Faild login.'));
-    console.log('Try "atam -l"');
-    browser.close();
-    process.exit(1);
-  }
+  const cookies = utils.getCookie();
+  if (cookies == null) process.exit(1);
+
+  const [page, browser] = await utils.createBrowser();
   await page.setCookie(...cookies);
 
   return [page, browser];
 };
 
-
-exports.loginByNameAndPW = loginByNameAndPW;
-exports.loginByCookie = loginByCookie;
+module.exports = {
+  loginByNameAndPW,
+  loginByCookie,
+};

--- a/src/mkdotfile.js
+++ b/src/mkdotfile.js
@@ -1,15 +1,11 @@
-#!/usr/bin/env node
-const fs = require('fs');
 const os = require('os');
+
+const utils = require('./utils');
 
 const dotfilePath = `${os.homedir()}/.atam`;
 
 function mkdotfile() {
-  try {
-    fs.readdirSync(dotfilePath);
-  } catch (e) {
-    fs.mkdirSync(dotfilePath);
-  }
+  utils.mkdirIfNotExists(dotfilePath);
 }
 
 exports.dotfilePath = dotfilePath;

--- a/src/mkdotfile.js
+++ b/src/mkdotfile.js
@@ -1,12 +1,8 @@
-const os = require('os');
-
 const utils = require('./utils');
-
-const dotfilePath = `${os.homedir()}/.atam`;
+const consts = require('./consts');
 
 function mkdotfile() {
-  utils.mkdirIfNotExists(dotfilePath);
+  utils.mkdirIfNotExists(consts.dotfilePath);
 }
 
-exports.dotfilePath = dotfilePath;
 exports.mkdotfile = mkdotfile;

--- a/src/options.js
+++ b/src/options.js
@@ -64,7 +64,7 @@ program
   .command('new <prob>')
   .alias('n')
   .description('Create dir tree')
-  .action(actions.createDirTree)
+  .action(actions.createDirTreeCmd)
   .on('--help', () => {
     utils.helpMessage({
       message: [

--- a/src/options.js
+++ b/src/options.js
@@ -61,6 +61,23 @@ program
   });
 
 program
+  .command('new <prob>')
+  .alias('n')
+  .description('Create dir tree')
+  .action(actions.createDirTree)
+  .on('--help', () => {
+    utils.helpMessage({
+      message: [
+        'prob (e.g.: abc001)',
+      ],
+      example: [
+        'new abc001',
+        'n abs',
+      ],
+    });
+  });
+
+program
   .parse(process.argv);
 
 module.exports = program;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,10 @@
 const puppeteer = require('puppeteer');
 const notifier = require('node-notifier');
+const https = require('https');
+const fs = require('fs');
+
+const color = require('./message_color');
+const consts = require('./consts');
 
 async function createBrowser() {
   const browser = await puppeteer.launch({
@@ -71,6 +76,39 @@ async function syncMap(array, f) {
   return prev.then(ret => result.slice(1).concat(ret));
 }
 
+function getCookie() {
+  try {
+    return JSON.parse(fs.readFileSync(consts.cookiePath, 'utf-8'));
+  } catch (e) {
+    console.log(color.error('Error!! Faild login.'));
+    console.log('Try "atam -l"');
+    return null;
+  }
+}
+
+function getRequest(prob, type, callback) {
+  const path = `/contests/${prob}/${type}`;
+  const { hostname } = new URL(consts.atcoderUrl);
+
+  const cookies = getCookie();
+  if (cookies == null) process.exit(1);
+  const cookie = cookies.map(e => `${e.name}=${e.value}`);
+  const headers = { cookie };
+
+  return new Promise((resolve) => {
+    const req = https.request({ hostname, path, headers }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => resolve(callback(data)));
+    });
+
+    req.end();
+  });
+}
+
 module.exports = {
   createBrowser,
   helpMessage,
@@ -78,4 +116,6 @@ module.exports = {
   waitFor,
   syncEach,
   syncMap,
+  getRequest,
+  getCookie,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,8 +112,10 @@ function getRequest(prob, type, callback) {
 function mkdirIfNotExists(path) {
   try {
     fs.readdirSync(path);
+    return false;
   } catch (e) {
     fs.mkdirSync(path);
+    return true;
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,6 +109,14 @@ function getRequest(prob, type, callback) {
   });
 }
 
+function mkdirIfNotExists(path) {
+  try {
+    fs.readdirSync(path);
+  } catch (e) {
+    fs.mkdirSync(path);
+  }
+}
+
 module.exports = {
   createBrowser,
   helpMessage,
@@ -118,4 +126,5 @@ module.exports = {
   syncMap,
   getRequest,
   getCookie,
+  mkdirIfNotExists,
 };


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
issueは立ってないです
#88 が作りやすくなるのかなと思います

個人的にとても欲しかったので作りました

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
atam new のコマンドが追加されました
atam new abc043 とかやるとcwdにabc043/が作成されます
abc043/の中にa, b, c, ...とディレクトリが作成されます
~abc043/の中にprobとディレクトリの対応表が格納された.atam.jsonが作成されます~
あると今後の処理が複雑になりそうだったので削除

何個か定数をconstsに移しました
何箇所か共通処理をまとめてutilsに移しました

puppeteerだと一度ブラウザを作成する関係上かなり重いので、ただ単にリクエスト投げたい時用にhttpsライブラリを使ってスクレイピングできる関数を生やしておきました。
今まで使用していたcookieを使ってログイン状態でリクエストを投げます。

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
constsとutilsに処理を移した関係上、影響範囲が大きいと思います
ログイン、提出、通知、サンプルチェックがそれぞれ動くのは一通り確認しました

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
httpsは標準モジュールなので追加などはないです

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
