### PR TITLE
引数にURLを与えて提出・テストできるようにする

### DIFF
--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -11,25 +11,28 @@ async function login() {
   loginMod.loginByNameAndPW();
 }
 
-async function submit(prob, filename) {
-  let paramFilename = filename;
-  let paramProb = prob;
+async function submit(prob, filenameOrEmpty) {
+  let filename = filenameOrEmpty;
+  let probId = prob;
+
   if (filename === undefined) {
-    paramFilename = prob;
-    paramProb = await dirTree.getProbFromCWD();
+    filename = prob;
+    probId = await dirTree.getProbFromCWD();
   }
 
-  if (paramProb === undefined) {
+  if (probId === undefined) {
     console.log(color.error('問題が不明です'));
     process.exit(1);
   }
 
+  probId = utils.unificationOfProb(probId);
+
   const [page, browser] = await loginMod.loginByCookie();
 
-  const sourceCode = gets.getSource(paramFilename);
-  const lang = await gets.getLangId(page, paramProb);
-  const task = await gets.getProblemId(page, paramProb);
-  await submitMod.submit(page, paramProb, task, lang, sourceCode);
+  const sourceCode = gets.getSource(filename);
+  const lang = await gets.getLangId(page, probId);
+  const task = await gets.getProblemId(page, probId);
+  await submitMod.submit(page, probId, task, lang, sourceCode);
   browser.close();
 }
 
@@ -67,16 +70,18 @@ function execSampleCase(commands, input, output) {
 }
 
 async function sample(prob, commands) {
+  const probId = utils.unificationOfProb(prob);
+
   const [page, browser] = await loginMod.loginByCookie();
-  const task = await gets.getProblemId(page, prob);
-  const samples = await gets.getSamples(page, prob, task);
+  const task = await gets.getProblemId(page, probId);
+  const samples = await gets.getSamples(page, probId, task);
   utils.syncMap(samples, value => execSampleCase(commands, ...value));
 
   browser.close();
 }
 
 async function createDirTreeCmd(prob) {
-  dirTree.createDirTree(prob);
+  dirTree.createDirTree(utils.unificationOfProb(prob));
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,6 +119,17 @@ function mkdirIfNotExists(path) {
   }
 }
 
+function urlToProb(url) {
+  return new URL(url).pathname.split('/')[2]; // '', 'contests', '<prob>', ...
+}
+
+function unificationOfProb(prob) {
+  if (prob.startsWith('https://')) {
+    return urlToProb(prob);
+  }
+  return prob;
+}
+
 module.exports = {
   createBrowser,
   helpMessage,
@@ -129,4 +140,5 @@ module.exports = {
   getRequest,
   getCookie,
   mkdirIfNotExists,
+  unificationOfProb,
 };


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#87 
urlがprobとして指定された場合、abc014など問題番号の部分だけ抜き出す処理を入れました
抜き出した後は今までと同様の処理を行います

適当なファイルに情報を保持する処理は、混ぜるとPRが長くなりそうだったのでひとまず分けました

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
probを引数に取っているコマンドに関して、urlかどうかを判別してprobを抜き出す処理を挿入しました
submit, test, newに入れていると思います

urlかどうかの判断は先頭がhttps://になっているかを見ています

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
submit, test, newのコマンドに対して影響があります

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特にないです

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
