### PR TITLE
ディレクトリ構成からサンプルを通す問題番号を推定する

### DIFF
--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -67,9 +67,20 @@ function execSampleCase(commands, input, output) {
 }
 
 async function sample(prob, commands) {
+  let probId = prob;
+  if (!await utils.probExists(probId)) {
+    commands.unshift(probId);
+    probId = await dirTree.getProbFromCWD();
+  }
+
+  if (probId === undefined) {
+    console.log(color.error('問題が不明です'));
+    process.exit(1);
+  }
+
   const [page, browser] = await loginMod.loginByCookie();
-  const task = await gets.getProblemId(page, prob);
-  const samples = await gets.getSamples(page, prob, task);
+  const task = await gets.getProblemId(page, probId);
+  const samples = await gets.getSamples(page, probId, task);
   utils.syncMap(samples, value => execSampleCase(commands, ...value));
 
   browser.close();

--- a/src/dir_tree.js
+++ b/src/dir_tree.js
@@ -31,14 +31,10 @@ async function getProbFromCWD() {
   const cwd = path.resolve('.').split('/');
 
   // 4階層上まで見る
-  const probs = await Promise.all(cwd.slice(cwd.lenght - 4).map(prob => utils.getRequest(prob, '', (data, response) => {
-    if (response.statusCode === 200) {
-      return prob;
-    }
-    return undefined;
-  })));
+  const probs = await Promise.all(cwd.slice(cwd.lenght - 4)
+    .map(async prob => await utils.probExists(prob) && prob));
 
-  const prob = probs.filter(value => value !== undefined)[0];
+  const prob = probs.filter(value => value !== false)[0];
   return prob;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,6 +119,11 @@ function mkdirIfNotExists(path) {
   }
 }
 
+async function probExists(prob) {
+  const result = await getRequest(prob, '', (data, response) => response.statusCode === 200);
+  return result;
+}
+
 module.exports = {
   createBrowser,
   helpMessage,
@@ -129,4 +134,5 @@ module.exports = {
   getRequest,
   getCookie,
   mkdirIfNotExists,
+  probExists,
 };


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#88 
#93 のPRで提出時だけcwdを使っていましたが、`atam test`でもcwdの情報を使えるようにしました。
`atam t python main.py`のように行います。

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
probが省略されているのかされていないのか判別つかなかったので、atcoderに存在しないprobの場合cwdから推定するように処理を書いています。

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
atam testコマンドに影響があります。
probが存在するかどうかの確認処理を関数にまとめたので、提出の方にも影響があるかもしれません。

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特になし

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
helpは依然そのままです
