### PR TITLE
ローカルの設定ファイルに引数などを保存

### DIFF
--- a/src/command_actions.js
+++ b/src/command_actions.js
@@ -119,25 +119,29 @@ async function sample(prob, commands, options) {
     process.exit(1);
   }
 
-  const [page, browser] = await loginMod.loginByCookie();
-
   if (config.sample.probId !== probId) {
+    config.sample.task = undefined;
     config.sample.samples = undefined;
   }
 
-  let { samples } = config.sample;
-  if (!samples) {
-    const task = await gets.getProblemId(page, probId);
-    samples = await gets.getSamples(page, probId, task);
+  let page;
+  let browser;
+  if (!config.sample.task || !config.sample.samples) {
+    [page, browser] = await loginMod.loginByCookie();
+  } else {
+    browser = undefined;
   }
+
+  const task = config.sample.task || await gets.getProblemId(page, probId);
+  const samples = config.sample.samples || await gets.getSamples(page, probId, task);
   utils.syncMap(samples, value => execSampleCase(commands, ...value));
 
   config.sample = {
-    probId, commands, samples,
+    task, probId, commands, samples,
   };
   configure.save(config);
 
-  browser.close();
+  if (browser) browser.close();
 }
 
 async function createDirTreeCmd(prob) {

--- a/src/configure.js
+++ b/src/configure.js
@@ -13,8 +13,8 @@ function get(options) {
   }
 }
 
-function save(config) {
-  fs.writeFileSync(consts.confPath, JSON.stringify(config));
+function save(config, dir = '.') {
+  fs.writeFileSync(`${dir}/${consts.confPath}`, JSON.stringify(config));
 }
 
 module.exports = {

--- a/src/configure.js
+++ b/src/configure.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+
+const consts = require('./consts');
+
+function get(options) {
+  if (options.force) {
+    return {};
+  }
+  try {
+    return JSON.parse(fs.readFileSync(consts.confPath, 'utf-8'));
+  } catch (e) {
+    return {};
+  }
+}
+
+function save(config) {
+  fs.writeFileSync(consts.confPath, JSON.stringify(config));
+}
+
+module.exports = {
+  get,
+  save,
+};

--- a/src/consts.js
+++ b/src/consts.js
@@ -5,6 +5,7 @@ module.exports = {
   dotfilePath,
   atcoderUrl: 'https://atcoder.jp',
   cookiePath: `${dotfilePath}/cookieLogin.json`,
+  confPath: '.atam.local.json',
 
   // more
 };

--- a/src/dir_tree.js
+++ b/src/dir_tree.js
@@ -3,6 +3,7 @@ const path = require('path');
 const utils = require('./utils');
 const gets = require('./gets');
 const color = require('./message_color');
+const configure = require('./configure');
 
 async function createDirTree(prob) {
   const root = `./${prob}`;
@@ -22,6 +23,18 @@ async function createDirTree(prob) {
   taskIds.forEach((dirName) => {
     const dir = `${root}/${dirName}`;
     if (utils.mkdirIfNotExists(dir)) {
+      const config = {
+        submit: {
+          task: dirMap[dirName],
+          probId: prob,
+        },
+        sample: {
+          task: dirMap[dirName],
+          probId: prob,
+        },
+      };
+
+      configure.save(config, dir);
       console.log(color.success(`create ${dir}`));
     }
   });

--- a/src/options.js
+++ b/src/options.js
@@ -27,6 +27,7 @@ program
 program
   .command('test <prob> [commands...]')
   .alias('t')
+  .option('-f, --force', 'Not use config file')
   .description('Check sample case')
   .action(actions.sample)
   .on('--help', () => {
@@ -46,6 +47,7 @@ program
 program
   .command('submit [prob] [filename]')
   .alias('s')
+  .option('-f, --force', 'Not use config file')
   .description('Submit your code')
   .action(actions.submit)
   .on('--help', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,23 +55,25 @@ async function waitFor(page, func) {
 }
 
 async function syncEach(array, f) {
+  const copiedArray = array.slice();
   const createFunc = value => () => f(value);
   let prev = Promise.resolve();
-  while (array.length !== 0) {
-    prev = prev.then(createFunc(array.shift()));
+  while (copiedArray.length !== 0) {
+    prev = prev.then(createFunc(copiedArray.shift()));
   }
   await prev;
 }
 
 async function syncMap(array, f) {
+  const copiedArray = array.slice();
   const result = [];
   const createFunc = value => (ret) => {
     result.push(ret);
     return f(value);
   };
   let prev = Promise.resolve();
-  while (array.length !== 0) {
-    prev = prev.then(createFunc(array.shift()));
+  while (copiedArray.length !== 0) {
+    prev = prev.then(createFunc(copiedArray.shift()));
   }
   return prev.then(ret => result.slice(1).concat(ret));
 }


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#87 の`一度URLからコマンドを実行したらURLを適当なファイルに保持して、以降URLを引数にしなくてもいいようにすると便利そうだなと思いました。`から来ています

入力した情報をcwdに保存して次回から省略できるようにします

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

submitとtestのコマンドに関して、引数やその結果を保存します
保存してある情報に関しては次回から省略できます

```
atam s abs main.py
atam s
```
のような感じです

submitに関して
`問題番号` `ファイル名` `選択した問題番号(aとかbとか)` `選択言語`が保存されます

testに関して
`問題番号` `実行コマンド` `取得したサンプル結果`が保存されます

一部省略にも対応しているはずです
`atam t python main.py`とかやると問題番号とかは設定ファイルから使ってくれます
`atam s abs`とかやるとファイル名は設定から、他の情報は取得し直してくれます

設定に関しては./.atam.config.jsonに保存されます
constsにパスが入っています

submitとtestのコマンドにoptionを追加しています
-f で設定ファイルを使わずに実行します(helpにも記載)
`atam s abs main.py -f`とかやるとどんな時でも言語選択やらが出てくると思います
設定ファイルは更新されます

utilsに作っていたsyncMapとかループ系が元の配列を破壊していたのでコピーを使うように直しました

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

submit, test以外には影響が出てないことを祈っています

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特になし

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
何かおかしいときは手動で設定ファイルを消すなどするといいかもしれません
