### PR TITLE
同じサンプルが重複して取得されるのを防ぐ

### DIFF
--- a/src/gets.js
+++ b/src/gets.js
@@ -37,7 +37,7 @@ async function getSamples(page, prob, task) {
 
   await page.goto(url);
 
-  let samples = await page.$$('pre[id^="pre-sample"]');
+  let samples = await page.$$('.lang-ja pre[id^="pre-sample"]');
   if (samples.length === 0) {
     samples = await page.$$('pre[id^="for_copy"]');
   }

--- a/src/gets.js
+++ b/src/gets.js
@@ -38,6 +38,11 @@ async function getSamples(page, prob, task) {
   await page.goto(url);
 
   let samples = await page.$$('.lang-ja pre[id^="pre-sample"]');
+
+  if (samples.length === 0) {
+    samples = await page.$$('pre[id^="pre-sample"]');
+  }
+
   if (samples.length === 0) {
     samples = await page.$$('pre[id^="for_copy"]');
   }


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
一部のコンテストでサンプルケースが重複して取得されていました
原因は、日本語ページのサンプルと英語ページのサンプルの両方が取得されていたことです
サンプルを取得する際に、.lang-jaの指定を加えて日本語ページからのみ取得するようにしました
言語の違いによってサンプルケースが異なることは無いと思うので、日本語ページでいいかなという感じです

昔のフォーマット(abc001とか)であれば重複は起きていませんでした

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
サンプル取得のセレクターに.lang-jaを加えました

最近のフォーマットでも.lang-jaの指定が全てのページにあるのかは不安だったので、言語指定が無いパターンも残してあります
ページを再取得するとかでは無いため、残しておいても速度にはほとんど影響無いのかなというところです

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
testコマンド

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
特になし

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
